### PR TITLE
Add a Dockerfile as a quicker quick-start.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SMDHTOOL := $(DEVKITARM)/bin/smdhtool
 all: $(CRATE_NAME) 
 
 target/3ds/release/$(CRATE_NAME).elf:
-	RUST_TARGET_PATH=$(PWD) xargo build --release
+	RUST_TARGET_PATH=$(shell pwd) xargo build --release
 
 target/3ds/release/$(CRATE_NAME).smdh:
 	$(SMDHTOOL) --create "${PROG_NAME}" "${PROG_DESC}" "${PROG_AUTHOR}" "${PROG_ICON}" target/3ds/release/$(CRATE_NAME).smdh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,56 @@
+# Based on https://github.com/liuchong/docker-rustup/blob/master/dockerfiles/nightly/Dockerfile.
+
+FROM debian:stretch
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    autoconf \
+    automake \
+    autotools-dev \
+    build-essential \
+    ca-certificates \
+    curl \
+    file \
+    libtool \
+    perl \
+    wget \
+    xutils-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /build
+WORKDIR /build
+
+# Install openssl. Seems to be a requirement for rustup.
+ENV SSL_VERSION=1.0.2k
+RUN curl https://www.openssl.org/source/openssl-$SSL_VERSION.tar.gz -O && \
+    tar -xzf openssl-$SSL_VERSION.tar.gz && \
+    cd openssl-$SSL_VERSION && ./config && make depend && make install && \
+    cd .. && rm -rf openssl-$SSL_VERSION*
+
+ENV OPENSSL_LIB_DIR=/usr/local/ssl/lib \
+    OPENSSL_INCLUDE_DIR=/usr/local/ssl/include \
+    OPENSSL_STATIC=1
+
+ENV PATH=/root/.cargo/bin:/root/devkitPro/devkitARM/bin:$PATH
+
+# Install rust and rust-src.
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain nightly -y
+RUN rustup component add rust-src
+
+# Install xargo
+RUN cargo install xargo
+
+# TODO(sirver): Figure out how to force xargo to build the sysroot now, so that it is part of the docker image and does not need to be rebuild on every make.
+
+# Install devkitARM. Link from http://3dbrew.org/wiki/Setting_up_Development_Environment.
+RUN curl -L http://sourceforge.net/projects/devkitpro/files/Automated%20Installer/devkitARMupdate.pl/download \
+   -o devkitARMupdate.pl
+RUN perl devkitARMupdate.pl
+
+ENV DEVKITPRO /root/devkitPro
+ENV DEVKITARM /root/devkitPro/devkitARM
+
+# Create working directory which will be shared between docker and computer.
+RUN mkdir -p /root/code
+WORKDIR /root/code

--- a/docker/run_in_docker.sh
+++ b/docker/run_in_docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker run -it --rm \
+	--net=host \
+	-v $(pwd):/root/code \
+	rust_3ds \
+   $*
+


### PR DESCRIPTION
This allowed me to get the hello world running on my 3DS by issuing
these commands on my Mac OS X:

$ cd docker
$ docker build . -t rust_3ds
$ cd ..
$ docker/run_in_docker.sh make
$ docker/run_in_docker.sh 3dslink -a 192.168.178.39 target/3ds/release/rust3ds-template.3dsx

This obviously requires docker. For Win/Mac install from https://www.docker.com/, for Linux install `docker-engine`.

Advantages:
- Building a Dockerfile allows for a hermetic, self contained
  development environment that can be easily version pinned without the
  loss of performance while building.
- The same environment can be used by Windows, Mac & Linux Developers
  without any change.
- The installation instructions are self-documented in the Dockerfile
  and can be replicated on any Linux host if an outside environment is
  desired.

Disadvantages:
- Docker is yet another tool that needs to be understood.

Caveats of the current implementation:
- Since only $(pwd) is shared with the docker container, the sysroots
  Xargo builds are not cached - this limits the usefulness of the
  Dockerfile, but it still is a good starting off point. Ideally we
  would like Xargo to build the sysroot either on creation of the docker
  container (i.e. in the Dockerfile) or build it inside target/ so that
  it is shared between computer and docker.