### PR TITLE
Update for Rust nightly-2018-04-19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,24 +6,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ctru-rs"
 version = "0.7.0"
-source = "git+https://github.com/rust3ds/ctru-rs#d46f9f45657dee9dc0277e5470fcf7e8bb3eb3e7"
+source = "git+https://github.com/rust3ds/ctru-rs#159b5b9e62ce074bbbd1900137670a9f5426a8bd"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctru-sys 0.4.0 (git+https://github.com/rust3ds/ctru-rs)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ctru-sys"
 version = "0.4.0"
-source = "git+https://github.com/rust3ds/ctru-rs#d46f9f45657dee9dc0277e5470fcf7e8bb3eb3e7"
+source = "git+https://github.com/rust3ds/ctru-rs#159b5b9e62ce074bbbd1900137670a9f5426a8bd"
 dependencies = [
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.36"
+version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -42,5 +43,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum ctru-rs 0.7.0 (git+https://github.com/rust3ds/ctru-rs)" = "<none>"
 "checksum ctru-sys 0.4.0 (git+https://github.com/rust3ds/ctru-rs)" = "<none>"
-"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ PROG_ICON := $(DEVKITPRO)/libctru/default_icon.png
 3DSXTOOL := $(DEVKITARM)/bin/3dsxtool
 SMDHTOOL := $(DEVKITARM)/bin/smdhtool
 
+export CC_3ds := $(DEVKITARM)/bin/arm-none-eabi-gcc
+export TARGET_CFLAGS := -specs=3dsx.specs -mfloat-abi=hard -march=armv6k -mtune=mpcore \
+						-mfpu=vfp -mtp=soft
+
 .PHONY: all clean $(CRATE_NAME) dist test send target/3ds/release/$(CRATE_NAME).elf
 
 all: $(CRATE_NAME) 
@@ -38,3 +42,6 @@ send: $(CRATE_NAME)
 clean:
 	rm -rf target
 	rm -rf dist
+
+nuke: clean
+	rm -rf ~/.xargo


### PR DESCRIPTION
Some extra environment variables had to be added to the Makefile because of recent changes to the way `compiler-builtins` gets included from the sysroot. I also added a `nuke` rule to the Makefile to clear out Xargo's sysroot, which is handy for times when you want to force it to be rebuilt.