### PR TITLE
Change 3DS' tools PATHs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ PROG_DESC := Rust, a modern, safe systems language.
 PROG_AUTHOR := You
 PROG_ICON := $(DEVKITPRO)/libctru/default_icon.png
 
-3DSXTOOL := $(DEVKITARM)/bin/3dsxtool
-SMDHTOOL := $(DEVKITARM)/bin/smdhtool
+3DSXTOOL := $(DEVKITPRO)/tools/bin/3dsxtool
+SMDHTOOL := $(DEVKITPRO)/tools/bin/smdhtool
 
 export CC_3ds := $(DEVKITARM)/bin/arm-none-eabi-gcc
 export TARGET_CFLAGS := -specs=3dsx.specs -mfloat-abi=hard -march=armv6k -mtune=mpcore \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you have already installed rustup:
 
 #### Installing devkitARM
 
-As of this writing, the current version of devkitARM is r47 and the current version of libctru is 1.4.0.
+As of this writing, the current version of devkitARM is r48 and the current version of libctru is 1.5.0.
 
 A detailed tutorial on how to set up devkitARM can be found on the [3dbrew wiki](http://3dbrew.org/wiki/Setting_up_Development_Environment).
 


### PR DESCRIPTION
With the introduction of the DevkitPro's PacMan way of installing 3DS dev tools, tools are now installed in the $(DEVKITPRO)/tools/bin/ folder instead of the old fourre-tout folder $(DEVKITARM)/bin/.

This PR will break compatibility with people using an old version of DevkitPro.